### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Things you may want to cover:
   |------|----|-------|
   |nickname|string|null: false|
   |birthday|date|null: false|
-  |password|integer|null: false|
   |first_name|string|null: false|
   |last_name|string|null: false|
   |first_name_kana|string|null: false|
@@ -48,7 +47,6 @@ Things you may want to cover:
   |postnumber|string|null: false|
   |prefecture|string|null: false|
   |city|string|null: false|
-  |house_number|string|null: false|
   |building|string||
   |phone_number|string||
   |user_id|integer|null: false, foreign_key: true|
@@ -74,11 +72,13 @@ Things you may want to cover:
   |price|integer|null: false|
   |brand|string||
   |size|integer|null: false|
-  |product_status|integer|null: false|
+  |product_status|boolean|null: false|
+  |trade_status|boolean|null: false|
   |delivery_fee|integer|null: false|
   |delivery_time|integer|null: false|
   |delivery_area|string||
   |user_id|integer|null: false, foreign_key: true|
+  |category_id|integer|null: false, foreign_key: true|
 
   Assosiation
   belongs_to :user
@@ -86,6 +86,7 @@ Things you may want to cover:
   belongs_to_active_hash :product_status
   belongs_to_active_hash :delivery_fee
   belongs_to_active_hash :delivery_time
+  belongs_to :categories
 
 
   images
@@ -96,6 +97,16 @@ Things you may want to cover:
 
   Assosiation
   belongs_to :product
+
+
+  categories
+  |Column|Type|Options|
+  |------|----|-------|
+  |category_name|string|null: false|
+  |ancestry|integer|null: false|
+
+  Associations
+  has_many :products
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,4 @@
-# README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
 
 
   users

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Things you may want to cover:
   |postnumber|string|null: false|
   |prefecture|string|null: false|
   |city|string|null: false|
+  |house_number|string|null: false|
   |building|string||
   |phone_number|string||
   |user_id|integer|null: false, foreign_key: true|
@@ -72,8 +73,8 @@ Things you may want to cover:
   |price|integer|null: false|
   |brand|string||
   |size|integer|null: false|
-  |product_status|boolean|null: false|
-  |trade_status|boolean|null: false|
+  |product_status|integer|null: false|
+  |trading_status|integer|null: false|
   |delivery_fee|integer|null: false|
   |delivery_time|integer|null: false|
   |delivery_area|string||
@@ -82,11 +83,12 @@ Things you may want to cover:
 
   Assosiation
   belongs_to :user
+  has_many :images
   belongs_to_active_hash :size
   belongs_to_active_hash :product_status
   belongs_to_active_hash :delivery_fee
   belongs_to_active_hash :delivery_time
-  belongs_to :categories
+  belongs_to :category
 
 
   images
@@ -103,7 +105,7 @@ Things you may want to cover:
   |Column|Type|Options|
   |------|----|-------|
   |category_name|string|null: false|
-  |ancestry|integer|null: false|
+  |ancestry|string|null: false|
 
   Associations
   has_many :products


### PR DESCRIPTION
what
スプリントレビューでusersテーブルのpasswordカラムはdeviseで自動作成されるため不要であること、productsテーブルにcategoriesテーブルを作成すること、そして、商品が売れたのかそうでないのかを判断するカラムが必要であることを指摘されたため、それらの削除と作成を行いました。
また、商品と取引の状態であるproduct_statusカラムtrade_statusの型はその特性上、integerよりbooleanの方が相応しいと考えたため、そっちに変更しました

why
スプリントレビューで指摘されたため


<img width="1011" alt="スクリーンショット 2020-09-16 0 22 53" src="https://user-images.githubusercontent.com/67854671/93264209-bd120b00-f7e1-11ea-9cd5-e02a7bc02ff5.png">
