### PR TITLE
Product_list_display_confirmation

### DIFF
--- a/app/views/items/_pickup_category.html.haml
+++ b/app/views/items/_pickup_category.html.haml
@@ -12,9 +12,7 @@
             .pickup_category__containerCategory__product--lists__list
               = link_to "#" do
                 %figure.pickup_category__product__images
-                  -# 商品一覧実装時はテスト画像利用のためコメントアウト。次回実装時にお使いくださいませ。
-                  -# = image_tag product.images.first.image.url
-                  = image_tag 'T-shirt.png',alt: "image_url", class:"pickup_brand__product__images--image"
+                  = image_tag product.images.first.image.url
                 .pickup_category__containerCategory__product--lists__list--body
                   %h3.pickup_category__product--name
                     = product.product_name
@@ -34,9 +32,7 @@
             .pickup_category__containerCategory__product--lists__list
               = link_to "#" do
                 %figure.pickup_category__product__images
-                  -# 商品一覧実装時はテスト画像利用のためコメントアウト。次回実装時にお使いくださいませ。
-                  -# = image_tag product.images.first.image.url
-                  = image_tag 'TankTop.png',alt: "image_url", class:"pickup_brand__product__images--image"
+                  = image_tag product.images.first.image.url
                 .pickup_category__containerCategory__product--lists__list--body
                   %h3.pickup_category__product--name
                     = product.product_name


### PR DESCRIPTION
## What

Trelloにてメンターコードレビュー完了済みである
【サーバサイド】商品一覧表示の
概要：出品された商品はトップページで一覧表示されるの修正

## Why
1：今までは出品する商品画像をassets/imagesから取得。
2：デプロイ担当者にてS3アップロード完了。
3：故にトップページに表示する画像を出品分と紐付けする実装を行った。
上記、実装をしないと同じ商品画像を利用することになるため。

## Confirmed

トップページにて出品画像の表示を確認
![Product_list_display_confirmation](https://media.giphy.com/media/pMTkraYFUdz82U0gyn/giphy.gif)

DBへの紐付け登録を確認
<img width="1416" alt="9647319b6a437a59dd77cc9cd8838875" src="https://user-images.githubusercontent.com/67244135/96123649-19299580-0f2e-11eb-8dbb-01cf62f797f0.png">

<img width="1413" alt="3783eb9453acc54e3f60d126e1988e32" src="https://user-images.githubusercontent.com/67244135/96123666-1e86e000-0f2e-11eb-94db-d269c04c0b24.png">

