### PR TITLE
【サーバサイド】商品削除

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,3 +34,9 @@
 // 商品詳細ページ
 @import "modules/product_detail";
 @import "modules/products_show";
+
+// 商品削除ページ
+@import "modules/products/products_delete";
+
+// 商品エラーページ
+@import "modules/products/not_found";

--- a/app/assets/stylesheets/modules/_products_show.scss
+++ b/app/assets/stylesheets/modules/_products_show.scss
@@ -321,6 +321,18 @@
           }
         }
       }
+      &__delete {
+        width: 100%;
+        text-align: center;
+        height: 40px;
+        line-height: 40px;
+        background-color: #ffb340;
+       
+        &--btn {
+          color: white;
+          text-decoration: none;
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/modules/products/_not_found.scss
+++ b/app/assets/stylesheets/modules/products/_not_found.scss
@@ -1,0 +1,10 @@
+.product-error-field {
+  text-align: center;
+    &__text {
+      font-size: 24px;
+      color: red;
+    }
+    &__detail {
+      margin: 20px 0px;
+    }
+}

--- a/app/assets/stylesheets/modules/products/_products_delete.scss
+++ b/app/assets/stylesheets/modules/products/_products_delete.scss
@@ -1,0 +1,9 @@
+.product-delete-field {
+  text-align: center;
+
+  &__text {
+    font-size: 24px;
+    margin: 20px 0px;
+  }
+
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,6 @@
 class ProductsController < ApplicationController
+  before_action :set_product, only: [:show, :destroy]
+
   def index
     @products = Product.includes(:images).order('created_at DESC')
   end
@@ -21,7 +23,28 @@ class ProductsController < ApplicationController
     end
   end
 
+  def show
+    @images = Image.where(product_id:@product.id)
+  end
+
+  def destroy
+    @product.destroy
+  end
+
+  # エラーページ用
+  def not_found
+  end
+
   private
+
+  def set_product
+    # レコードの存在を確認し、なければnot_foundを返す
+    if Product.exists?(params[:id])
+      @product = Product.find(params[:id])
+    else
+      redirect_to not_found_path
+    end  
+  end
 
   def product_params
     params.require(:product).permit(:product_name, :product_detail, :category, :brand, :delivery_area, :price, :size_id, :product_status_id, :delivery_fee_id, :delivery_time_id, :trading_status,images_attributes: [:image]).merge(user_id: current_user.id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,11 +24,13 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @images = Image.where(product_id:@product.id)
   end
 
   def destroy
-    @product.destroy
+    if @product.destroy
+    else
+      flash.now[:alert] = '削除に失敗しました'
+    end
   end
 
   # エラーページ用

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -27,10 +27,7 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    if @product.destroy
-    else
-      flash.now[:alert] = '削除に失敗しました'
-    end
+    flash.now[:alert] = '削除に失敗しました' unless @product.destroy  
   end
 
   # エラーページ用

--- a/app/views/items/_pickup_category.html.haml
+++ b/app/views/items/_pickup_category.html.haml
@@ -10,11 +10,11 @@
         - @products.each do |product|
           -if product.trading_status == 2
             .pickup_category__containerCategory__product--lists__list
-              = link_to "#" do
+              = link_to product_path(product) do
                 %figure.pickup_category__product__images
                   -# 商品一覧実装時はテスト画像利用のためコメントアウト。次回実装時にお使いくださいませ。
-                  -# = image_tag product.images.first.image.url
-                  = image_tag 'T-shirt.png',alt: "image_url", class:"pickup_brand__product__images--image"
+                  = image_tag product.images.first.image.url
+                  -# = image_tag 'T-shirt.png',alt: "image_url", class:"pickup_brand__product__images--image"
                 .pickup_category__containerCategory__product--lists__list--body
                   %h3.pickup_category__product--name
                     = product.product_name
@@ -32,11 +32,11 @@
                     sold
           - else
             .pickup_category__containerCategory__product--lists__list
-              = link_to "#" do
+              = link_to product_path(product)  do
                 %figure.pickup_category__product__images
                   -# 商品一覧実装時はテスト画像利用のためコメントアウト。次回実装時にお使いくださいませ。
-                  -# = image_tag product.images.first.image.url
-                  = image_tag 'TankTop.png',alt: "image_url", class:"pickup_brand__product__images--image"
+                  = image_tag product.images.first.image.url
+                  -# = image_tag 'TankTop.png',alt: "image_url", class:"pickup_brand__product__images--image"
                 .pickup_category__containerCategory__product--lists__list--body
                   %h3.pickup_category__product--name
                     = product.product_name

--- a/app/views/products/destroy.html.haml
+++ b/app/views/products/destroy.html.haml
@@ -1,0 +1,10 @@
+.entire_box
+  .new__page__header
+    = link_to image_tag("logo/logo.png", alt: "logo"), root_path
+
+  .product-delete-field
+    .product-delete-field__text
+      商品の削除が完了しました。
+    .product-delete-field__link
+      = link_to 'トップページに戻る', root_path 
+

--- a/app/views/products/not_found.html.haml
+++ b/app/views/products/not_found.html.haml
@@ -1,0 +1,14 @@
+.entire_box
+  .new__page__header
+    = link_to image_tag("logo/logo.png", alt: "logo"), root_path
+
+  .product-error-field
+    .product-error-field__text
+      ＜Not_Found＞お探しのページは見つかりませんでした。
+    .product-error-field__detail
+      この商品は削除された可能性があります。
+      %br
+      お手数ですが、トップページから操作をやり直してください。
+    .product-error-field__link
+      = link_to 'トップページに戻る', root_path 
+

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -135,6 +135,9 @@
                   1
                 %p.tax-include
                   (税込)
+      - if @product.user_id == current_user.id
+        .contents__delete
+          = link_to 'この商品を削除する', product_path(@product), method: :delete, data: { confirm: 'この商品を削除してよろしいですか' }, class:"contents__delete--btn"
 
 = render "items/app_banner"
 = render "items/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,11 @@ Rails.application.routes.draw do
   resources :mypages, only: [:show, :index]
   resources :creditcards, only: [:new, :create, :edit, :update, :index, :show]
 
-  resources :products, except: :show  
+  resources :products
   resources :addresses , only: [:new, :create ]
+
+  # 削除済商品へのアクセスした場合のエラー画面を表示するためのルーティング
+  get 'not_found', to:'products#not_found'
+  
   end
 


### PR DESCRIPTION
# What
フリマアプリにおける投稿した商品の削除機能を実装
・投稿者のみが削除可能
・（ブラウザバックなどで）削除後の商品ページへの遷移時、エラー画面を表示

操作イメージ
[![Image from Gyazo](https://i.gyazo.com/ef2d9c68c600e8ef55ecd86f76a139f0.gif)](https://gyazo.com/ef2d9c68c600e8ef55ecd86f76a139f0)

投稿ユーザーでないと削除ボタンはでない
[![Image from Gyazo](https://i.gyazo.com/a6b18ec20c468d2a5562d794bb0d0910.png)](https://gyazo.com/a6b18ec20c468d2a5562d794bb0d0910)

エラー画面
[![Image from Gyazo](https://i.gyazo.com/83eb38697b97c03623e136fe99974d06.png)](https://gyazo.com/83eb38697b97c03623e136fe99974d06)

データ削除前（product_id:26)
[![Image from Gyazo](https://i.gyazo.com/8420d14d662b4032f47d4f6d713e2fa9.png)](https://gyazo.com/8420d14d662b4032f47d4f6d713e2fa9)
[![Image from Gyazo](https://i.gyazo.com/a923e04b8cd28e80060bfdc856190a12.png)](https://gyazo.com/a923e04b8cd28e80060bfdc856190a12)


データ削除後（product_id:26が消えていることを確認)
[![Image from Gyazo](https://i.gyazo.com/db786fc94e9060301961d2449b94444e.png)](https://gyazo.com/db786fc94e9060301961d2449b94444e)
[![Image from Gyazo](https://i.gyazo.com/4d6c2374c9759b52e05c42884adc4952.png)](https://gyazo.com/4d6c2374c9759b52e05c42884adc4952)


# Why
商品削除を可能にするため