### PR TITLE
editing_product_information

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,3 +40,6 @@
 
 // 商品エラーページ
 @import "modules/products/not_found";
+
+// 商品編集ページ
+@import "modules/products/products_edit";

--- a/app/assets/stylesheets/modules/_products_show.scss
+++ b/app/assets/stylesheets/modules/_products_show.scss
@@ -333,6 +333,18 @@
           text-decoration: none;
         }
       }
+      &__edit{
+        width: 100%;
+        text-align: center;
+        height: 40px;
+        line-height: 40px;
+        background-color: #3CCACE;
+        margin-top: 10px;
+        &--btn{
+          color: white;
+          text-decoration: none;
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/modules/products/_products_edit.scss
+++ b/app/assets/stylesheets/modules/products/_products_edit.scss
@@ -1,0 +1,368 @@
+*{
+  box-sizing: border-box;
+}
+
+.entire_box{
+  display:flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: #F0F0F0;
+  .new__page__header{
+    height: 80px;
+    text-align: center;
+    padding-top: 15px;
+    img {
+      width: 150px;
+      cursor: pointer;
+      margin-bottom: 20px;
+    }
+  }
+  .product__field{
+    background-color: white;
+    margin: 0px auto;
+    width: 700px;
+    &__box{
+      @include product_box(200px);
+      .product__label{
+        display: flex;
+        &__name{
+          @include product_name;
+        }
+        &__required{
+          @include product_required(#3ccace);
+        }
+      }
+      .image-box, .previews{
+        margin: 20px 18px 0 0;
+        height: 110px;
+        background-color: #F0F0F0;
+        border: 1px dashed rgb(204, 204, 204);
+        cursor: pointer;
+        &__label{
+          height:130px;
+            i{
+              height: 100px;
+              width: 640px;
+              padding: 45px 360px 0px 320px;
+            }
+            .Hidden{
+              display:none;
+            }
+        }
+      }
+
+    }
+    .product__name__box{
+      @include product_box(130px);
+      .product__textField{
+        display: flex;
+        &__name{
+          @include product_name;
+        }
+        &__required{
+          @include product_required(#3ccace);
+        }
+      }
+      .product_field{
+        @include product_field;
+      }
+    }
+    .product__explanation__box{
+      @include product_box(100px);
+      .product__explanationField{
+        display: flex;
+        &__name{
+          @include product_name;
+        }
+        &__required{
+          @include product_required(#3ccace);
+        }
+      }
+      .style_textarea{
+        margin-top: 16px;
+        width: 641px;
+        height: 140px;
+        padding: 8px;
+      }
+    }
+    .product__category__box{
+      @include product_box(100px);
+      margin-top: 130px;
+      .product__details{
+        @include product_name;
+        color: rgb(204, 204, 204);
+        margin-bottom: 24px;
+        .product__categoryField{
+          @include product_fieldBox;
+          &__name{
+            @include product_name;
+            color:black;
+          }
+          &__required{
+            @include product_required(#3ccace);
+          }
+        }
+        .category__styleSelect{
+          margin-top: 16px;
+          &__selectarea{
+            select{
+              @include product_select;
+            }
+          }
+        }
+      }
+    }
+    .product__brand__box{
+      @include product_box(100px);
+      margin-top: 50px;
+      .product__brandField{
+        @include product_fieldBox;
+        &__name{
+          @include product_name;
+        }
+        &__required{
+          @include product_required(#bfbfbf);
+        }
+      }
+      .brand_field{
+        @include product_field;
+      }
+    }
+    .product__status__box{
+      @include product_box(100px);
+      margin-top: 50px;
+      .product__statusField{
+        @include product_fieldBox;
+        &__name{
+          @include product_name;
+        }
+        &__required{
+          @include product_required(#3ccace);
+        }
+      }
+      .category__statusSelect{
+        margin-top: 16px;
+        &__selectarea{
+          select{
+            @include product_select;
+          }
+        }
+      }
+    }
+    .product__size__box{
+      @include product_box(100px);
+      margin-top: 50px;
+      .product__sizeField{
+        @include product_fieldBox;
+        &__name{
+          @include product_name;
+        }
+        &__required{
+          @include product_required(#3ccace);
+        }
+      }
+      .category__sizeSelect{
+        margin-top: 16px;
+        &__selectarea{
+          select{
+            @include product_select;
+            font-weight: 550;
+          }
+        }
+      }
+
+
+    }
+    .product__delivery__box{
+      @include product_box(100px);
+      margin-top: 80px;
+      .product__regardingDelivery{
+        @include product_name;
+        color: rgb(204, 204, 204);
+        margin-bottom: 24px;
+        .product__deliveryField{
+          @include product_fieldBox;
+          &__name{
+            @include product_name;
+            color:black;
+            }
+          &__required{
+            @include product_required(#3ccace);
+          }
+        }
+        .delivery__styleSelect{
+          margin-top: 16px;
+          &__selectarea{
+            select{
+              @include product_select;
+            }
+          }
+        }
+      }
+    }
+    .product__area__box{
+      @include product_box(100px);
+      margin-top: 50px;
+      .product__areaField{
+        @include product_fieldBox;
+        &__name{
+          @include product_name;
+          color:black;
+        }
+        &__required{
+          @include product_required(#3ccace);
+        }
+      }
+      .category__areaSelect{
+        margin-top: 16px;
+        &__selectarea{
+          select{
+            @include product_select;
+          }
+        }
+      }
+    }
+    .product__shippingDays__box{
+      @include product_box(100px);
+      margin-top: 50px;
+      .product__shippingDaysField{
+        @include product_fieldBox;
+        &__name{
+          @include product_name;
+          color:black;
+        }
+        &__required{
+          @include product_required(#3ccace);
+        }
+      }
+      .category__shippingDaysSelect{
+        margin-top: 16px;
+        &__selectarea{
+          select{
+            @include product_select;
+          }
+        }
+      }
+    }
+    .product__price__box{
+      @include product_box(100px);
+      margin-top: 80px;
+      .product__priceRange{
+        @include product_name;
+        color: rgb(204, 204, 204);
+        margin-bottom: 24px;
+        .product__priceField{
+          @include product_priceBox;
+          margin-top: 40px;
+          &__box{
+            width: 470px;
+            display: flex;
+            &__name{
+              @include product_name;
+              color:black;
+            }
+            &__required{
+              @include product_required(#3ccace);
+            }
+          }
+          .test{
+            display: flex;
+            .product__price__yen{
+              font-size: 14px;
+              margin-right: 8px;
+              color: rgb(51, 51, 51);
+              padding-top: 15px;
+            }
+            .product__priceRangeBox{
+              align-items: center;
+              display: inline-flex;
+              padding-right: 20px;
+              &__inputarea{
+                input{
+                  width: 150px;
+                  height: 50px;
+                  text-align: right;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    .product__submitBotton__box{
+      @include product_box(100px);
+      margin-top: 50px;
+      .product__submitBottonField{
+        @include product_priceBox;
+        padding-bottom: 50px;
+        margin-top: 40px 20px 0 0;
+        &__button{
+          background-color: #3ccace;
+          color: #fff;
+          font-size: 17px;
+          min-height: 48px;
+          width:100%;
+          border-style:none;
+          margin-right: 20px;
+        }
+      }
+    }
+  }
+}
+
+
+// 商品画像プレビュー表示箇所
+
+#previews {
+  width: 650px;
+  display: flex;
+  margin-top: 10px;
+  text-align: center;
+}
+
+.image-preview {
+  width: 50px;
+  height: 50px;
+  &__wrapper {
+    height: 100px;
+    background-color: #F0F0F0;
+  }
+}
+
+img.preview {
+  width: 100px;
+  height: 100px;
+}
+
+.input {
+  background-color: #F0F0F0;
+  width: 650px;
+  margin :0px 25px;
+  height: 100px;
+  border: dashed 1px grey;
+  padding-top: 10px;
+}
+
+.input-area {
+  height: 50px;
+  line-height: 50px;
+}
+
+.image-preview {
+  &__wrapper {  
+    height: 50px;
+  }
+}
+
+.image-preview_btn_delete {
+  height: 30px;
+  background-color: #ffb340;
+  width: 100px;
+  color: white;
+  line-height: 30px;
+  margin: 0px auto;
+}
+
+.hidden {
+  display: none;
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :set_product, only: [:show, :destroy]
+  before_action :set_product, only: [:show, :destroy, :edit, :update]
 
   def index
     @products = Product.includes(:images).order('created_at DESC')
@@ -10,6 +10,24 @@ class ProductsController < ApplicationController
     @product.images.new
     unless user_signed_in?
       redirect_to new_user_session_path
+    end
+  end
+
+  def edit
+    @product.images.new
+    # カテゴリー機能未実装のため下記コメントアウト
+    # grandchild_category = @product.category
+    # child_category = grandchild_category.parent
+    # @category_parent_array = Category.where(ancestry: nil)
+    # @category_children_array = Category.where(ancestry: child_category.ancestry)
+    # @category_grandchildren_array = Category.where(ancestry: grandchild_category.ancestry)
+  end
+
+  def update
+    if @product.update(product_params)
+      redirect_to product_path(@product.id)
+    else
+      redirect_to action: :edit
     end
   end
 
@@ -46,6 +64,6 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.require(:product).permit(:product_name, :product_detail, :category, :brand, :delivery_area, :price, :size_id, :product_status_id, :delivery_fee_id, :delivery_time_id, :trading_status,images_attributes: [:image]).merge(user_id: current_user.id)
+    params.require(:product).permit(:product_name, :product_detail, :category, :brand, :delivery_area, :price, :size_id, :product_status_id, :delivery_fee_id, :delivery_time_id, :trading_status,images_attributes: [:image, :id, :_destory]).merge(user_id: current_user.id)
   end
 end

--- a/app/views/layouts/_error_messages.html.haml
+++ b/app/views/layouts/_error_messages.html.haml
@@ -1,0 +1,5 @@
+- if model.errors.any?
+  .alert-warning
+  %ul 
+  - model.errors.full_messages.each do |message|
+    %li.error-messages= message

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,0 +1,134 @@
+- if user_signed_in? 
+  = form_with model: @product, local:true do |f|
+    = render 'error_messages'
+    .entire_box
+      .new__page__header
+        = link_to image_tag("logo/logo.png", alt: "logo"), root_path
+      .product__field
+        .product__field__box
+          .product__label
+            .product__label__name      
+              出品画像
+            .product__label__required
+              必須
+            .product__label__text
+              ※最大5枚までアップロードできます
+          .form-image
+            = f.fields_for :images do |image|
+              .image_file_box
+                // 写真のプレビューとインプットボタンのul
+                %ul#previews
+                  - @product.images.each do |image|
+                    %li.image-preview
+                      -if image.persisted?
+                        = image_tag image.image.url
+                        .image-preview_btn
+                          .image-preview_btn_delete
+                            削除
+                  %li.input
+                    // 画像を取り込むインプットボタン
+                    %label.upload-label
+                      .upload-label__text
+                        ファイルをアップロード
+                      .input-area
+                        = icon('fas fa', 'camera', class:'image-icon')
+                        = image.file_field :image, class: "hidden image_upload"
+
+        .product__name__box
+          .product__textField
+            .product__textField__name      
+              商品名
+            .product__textField__required
+              必須
+          -# = text_field_tag "product_name", "", {class: "product_field",placeholder: "40字まで"}
+          = f.text_field :product_name, placeholder: "40字まで", class: "product_field", required: "required"
+        .product__explanation__box
+          .product__explanationField
+            .product__explanationField__name      
+              商品の説明
+            .product__explanationField__required
+              必須
+          = f.text_area :product_detail, placeholder:  "商品の説明（必須 1,000文字以内）\n（色、素材、重さ、定価、注意点など）\n\n例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。\n  ", rows: "7", class: "style_textarea"
+        .product__category__box
+          .product__details
+            商品の詳細
+            .product__categoryField
+              .product__categoryField__name      
+                カテゴリー
+              .product__categoryField__required
+                必須
+            .category__styleSelect
+              .category__styleSelect__selectarea
+                = f.select :category, [["カテゴリー（仮）", 0], ["レディース", 1], ["メンズ", 2], ["ベビー・キッズ", 3], ["インテリア・住まい・子供", 4]]
+        .product__brand__box
+          .product__brandField
+            .product__brandField__name      
+              ブランド
+            .product__brandField__required
+              任意
+          = text_field "brand_name", "", {class: "brand_field",placeholder: "例） シャネル"}
+        .product__status__box
+          .product__statusField
+            .product__statusField__name      
+              商品の状態
+            .product__statusField__required
+              必須
+          .category__statusSelect
+            .category__statusSelect__selectarea
+              = f.collection_select :product_status_id, ProductStatus.all, :id, :name, prompt: "選択してください", required: "required"
+        .product__size__box
+          .product__sizeField
+            .product__sizeField__name      
+              サイズ
+            .product__sizeField__required
+              必須
+          .category__sizeSelect
+            .category__sizeSelect__selectarea
+              = f.collection_select :size_id, Size.all, :id, :name, prompt: "選択してください", required: "required"
+        .product__delivery__box
+          .product__regardingDelivery
+            配送について
+            .product__deliveryField
+              .product__deliveryField__name      
+                配送料の負担
+              .product__deliveryField__required
+                必須
+            .delivery__styleSelect
+              .delivery__styleSelect__selectarea
+                = f.collection_select :delivery_fee_id, DeliveryFee.all, :id, :name, prompt: "選択してください", required: "required"
+        .product__area__box
+          .product__areaField
+            .product__areaField__name      
+              発送元の地域
+            .product__areaField__required
+              必須
+          .category__areaSelect
+            .category__areaSelect__selectarea
+              = f.select :delivery_area, ["北海道","青森県","岩手県","宮城県","秋田県","山形県","福島県","茨城県","栃木県","群馬県","埼玉県","千葉県","東京都","神奈川県","新潟県","富山県","石川県","福井県","山梨県","長野県","岐阜県","静岡県","愛知県","三重県","滋賀県","京都府","大阪府","兵庫県","奈良県","和歌山県","鳥取県","島根県","岡山県","広島県","山口県","徳島県","香川県","愛媛県","高知県","福岡県","佐賀県","長崎県","熊本県","大分県","宮崎県","鹿児島県","沖縄県","未定"], { include_blank: true, selected: @product.delivery_area,required: "required" },{id: "delivery_area", class: "sell-collection_select__input", prompt: "選択してください"}
+        .product__shippingDays__box
+          .product__shippingDaysField
+            .product__shippingDaysField__name      
+              発送までの日数
+            .product__shippingDaysField__required
+              必須
+          .category__shippingDaysSelect
+            .category__shippingDaysSelect__selectarea
+              = f.collection_select :delivery_time_id, DeliveryTime.all, :id, :name, prompt: "選択してください"
+        .product__price__box
+          .product__priceRange
+            価格（¥300〜9,999,999）
+            .product__priceField
+              .product__priceField__box
+                .product__priceField__box__name      
+                  販売価格
+                .product__priceField__box__required
+                  必須
+              .test
+                .product__price__yen
+                  ￥
+                .product__priceRangeBox
+                  .product__priceRangeBox__inputarea
+                    = f.number_field :price, placeholder: "入力してください"
+        .product__submitBotton__box
+          .product__submitBottonField
+            = f.submit "編集する", class:'product__submitBottonField__button'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -138,7 +138,9 @@
       - if @product.user_id == current_user.id
         .contents__delete
           = link_to 'この商品を削除する', product_path(@product), method: :delete, data: { confirm: 'この商品を削除してよろしいですか' }, class:"contents__delete--btn"
-
+      -if @product.user_id == current_user.id
+        .contents__edit
+          = link_to "この商品を編集する", edit_product_path(@product.id), class: 'contents__edit--btn'
 = render "items/app_banner"
 = render "items/footer"
 = render "items/display_btn"


### PR DESCRIPTION
## What

商品編集機能の実装

## Why

編集がされなければ出品した商品ごとに削除と新規登録を繰り返すため。

## Attention

カテゴリー機能と商品詳細機能は他メンバー実装中。
故に
１：編集しても画像や情報変更のview反映はされません。
２：カテゴリーの紐付けはしておりません。
３：以下のGIFは全て編集後にDBへの反映確認より”正”としております。

## Video

以下、完了定義GIF

商品情報（画像・商品名・カテゴリー・ブランド名・金額）を変更する事ができる。
※GIFでは商品名を変更

![変更](https://media.giphy.com/media/Osg4tZ6aO0otH6wRgH/giphy.gif)

画像の差し替えは一枚毎にできる。（ruby.png→php-logo.png ）
※動画解析度のせいか分かりづらいですが、DBにて変更確認済み。

![差し替え](https://media.giphy.com/media/C0KtrlS6so1N4cy7VX/giphy.gif)


何も編集せずに更新をしても画像なしの商品にならない。
※この場合はSequel Proにてリロードしてもphp-logo.pngから変更無し

![編集無し](https://media.giphy.com/media/QFNaBOb9pQTHQdBAoi/giphy.gif)


投稿者だけが編集ページに遷移できるようになっている。
※投稿者のみ編集ボタンと削除ボタンが表示

![投稿者のみ](https://media.giphy.com/media/91n2L0D9gyXpEKGLIh/giphy.gif)

商品出品時とほぼ同じUIで編集機能が実装出来ている。
※左:edit（編集UI） 右：new（出品UI）

![UI](https://media.giphy.com/media/ybD2GZW4HkldOLg1wS/giphy.gif)

画像等の情報がすでに登録されている商品情報が、編集画面を開いた時点でもれなく表示されるようになっている。
※DBだとID：4 (一番下の情報)が編集画面に表示されている。

![UI](https://media.giphy.com/media/CvA8ZTSlQtz2iIj6bK/giphy.gif)

エラーハンドリング

![エラー](https://media.giphy.com/media/vvra4R1KW0fpOMEE65/giphy.gif)


※テスト
pendingは編集機能とは別のためテスト通過。

<img width="409" alt="商品編集テスト" src="https://user-images.githubusercontent.com/67244135/97098959-54faf280-16c6-11eb-9b4e-512e32fe0456.png">

