### PR TITLE
商品購入、確認画面での画像と金額、カード情報の表示

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -60,6 +60,7 @@ class ProductsController < ApplicationController
 
   # 購入確認ページへ遷移
   def purchase_check
+    @product_s = Product.find(params[:id])
     creditcard = Creditcard.where(user_id: current_user.id).last
     if creditcard.blank?
       redirect_to controller: "creditcards", action: "new"
@@ -72,19 +73,25 @@ class ProductsController < ApplicationController
 
   # 購入完了ページに遷移
   def purchase_completed
+    @product_s = Product.find(params[:id])
     creditcard = Creditcard.where(user_id: current_user.id).last
     Payjp.api_key = ENV['PAYJP_ACCESS_KEY']
     Payjp::Charge.create(
-    :amount => 13500, #支払金額を入力(現状固定)
+    :amount => @product_s.price,
     :customer => creditcard.customer_id, #顧客ID
     :currency => 'jpy', #日本円
     )
     @product.update(trading_status: 2)
-    redirect_to action: 'done'
+    redirect_to done_product_path(@product)
   
   end
 
   def done
+    @product_s = Product.find(params[:id])
+    creditcard = Creditcard.where(user_id: current_user.id).last
+    Payjp.api_key = ENV['PAYJP_ACCESS_KEY']
+    customer = Payjp::Customer.retrieve(creditcard.customer_id)
+    @default_card_information = customer.cards.retrieve(creditcard.card_id)
   end
   
   private

--- a/app/views/products/done.html.haml
+++ b/app/views/products/done.html.haml
@@ -17,13 +17,22 @@
         %b 購入内容の確認
     .contents__detail__pic
       .contents__detail__pic__confirm
-        = image_tag 'pict/beef.jpg', alt: 'beef', class: 'beef-pic'
+        = image_tag @product_s.images.first.image.url, class: 'beef-pic'
     .contents__detail__price
       .contents__detail__price__confirm
         %b 支払い金額
+        ¥
+        = @product_s.price
     .contents__detail__method
       .contents__detail__method__confirm
         %b 支払い方法
+        - if @default_card_information.blank?
+          %br /
+        - else
+          = "**** **** **** " + @default_card_information.last4
+          - exp_month = @default_card_information.exp_month.to_s
+          - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+          = exp_month + " / " + exp_year
     .contents__detail__address
       .contents__detail__address__confirm
         %b 配送先

--- a/app/views/products/purchase_check.html.haml
+++ b/app/views/products/purchase_check.html.haml
@@ -9,10 +9,13 @@
         %b 購入内容の確認
     .contents__detail__pic
       .contents__detail__pic__confirm
-        = image_tag 'pict/beef.jpg', alt: 'beef', class: 'beef-pic'
+        = image_tag @product_s.images.first.image.url, class: 'beef-pic'
     .contents__detail__price
       .contents__detail__price__confirm
-        %b 支払い金額
+        %span.price
+          %b 支払い金額
+          ¥
+          = @product_s.price
     .contents__detail__method
       .contents__detail__method__confirm
         %b 支払い方法

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,16 +18,15 @@ Rails.application.routes.draw do
   
   resources :products do
     collection do
-      get 'done', to: 'products#done'
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
     end
     member do
       get 'purchase_check', to:'products#purchase_check'
       post 'purchase_completed', to:'products#purchase_completed'
+      get 'done', to: 'products#done'
       get 'products/:id' => 'products#show'
       get 'purchase_completed'
-
     end
   end
 


### PR DESCRIPTION
# what
商品購入時に、正しく商品の画像が表示されるように変数を使い修正
（今までは肉の画像で固定でした）
商品金額においても正しく商品の金額が表示されるように変数を使い修正
（今までは金額表示無し、決済金額は固定でした）
カード情報においても表示がされなかった部分を表示されるように修正
２枚目、３枚目の画像、ぱっと見同じようですがURLご確認ください。
２枚目が購入のページ、３枚目は購入後のページです。
購入後画面(done)のページに商品画像、金額等を表示されるため（商品情報を前ページより引き継ぐため）、ルーティングをcollection→memberに変更しました。本番環境と見比べていただくとより分かりやすいかと思います。
キノコの金額はpayjpにも反映を確認できます。
<img width="960" alt="スクリーンショット 2020-11-08 18 49 22" src="https://user-images.githubusercontent.com/67197096/98462251-392f3a80-21f6-11eb-99f3-b49ba515ec31.png">
<img width="954" alt="スクリーンショット 2020-11-08 18 49 47" src="https://user-images.githubusercontent.com/67197096/98462257-40eedf00-21f6-11eb-9c6e-c9a96244cc4d.png">
<img width="953" alt="スクリーンショット 2020-11-08 18 50 10" src="https://user-images.githubusercontent.com/67197096/98462258-43e9cf80-21f6-11eb-8a3a-fc52bcd7155d.png">
<img width="748" alt="スクリーンショット 2020-11-08 18 50 37" src="https://user-images.githubusercontent.com/67197096/98462260-46e4c000-21f6-11eb-8ed6-58f92512c563.png">



