### PR TITLE
Upload_editing_features

### DIFF
--- a/app/assets/stylesheets/modules/products/_products_edit.scss
+++ b/app/assets/stylesheets/modules/products/_products_edit.scss
@@ -323,8 +323,9 @@
 }
 
 .image-preview {
-  width: 50px;
+  width: 120px;
   height: 50px;
+  flex-shrink: 0;
   &__wrapper {
     height: 100px;
     background-color: #F0F0F0;

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -19,8 +19,8 @@
                 // 写真のプレビューとインプットボタンのul
                 %ul#previews
                   - @product.images.each do |image|
-                    %li.image-preview
-                      -if image.persisted?
+                    -if image.persisted?
+                      %li.image-preview
                         = image_tag image.image.url
                         .image-preview_btn
                           .image-preview_btn_delete


### PR DESCRIPTION
## What
編集ページ遷移の際の画像表示のview調整

##WHY
当初は画像同士が一塊の様なのviewだったので調整が必要のため
<img width="698" alt="修正" src="https://user-images.githubusercontent.com/67244135/98462926-1ce1cc80-21fb-11eb-8310-62ea8f3e0bbf.png">
