### PR TITLE
【商品詳細ページ】商品画像の取込、詳細ページへのリンク付け

### DIFF
--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,8 +1,4 @@
 .wrapper
-  = render 'product_detail'
-  = render 'items/app_banner'
-  = render 'items/footer'
-  = render "items/header"
 .pickup_category__containerCategory
   %h2.pickup_category__containerCategory__title
     ピックアップカテゴリー
@@ -14,11 +10,9 @@
       - @products.each do |product|
         -if product.trading_status == 2
           .pickup_category__containerCategory__product--lists__list
-            = link_to "#" do
+            = link_to product_path(product) do
               %figure.pickup_category__product__images
-                -# 商品一覧実装時はテスト画像利用のためコメントアウト。次回実装時にお使いくださいませ。
-                -# = image_tag product.images.first.image.url
-                = image_tag 'T-shirt.png',alt: "image_url", class:"pickup_brand__product__images--image"
+                = image_tag product.images.first.image.url
               .pickup_category__containerCategory__product--lists__list--body
                 %h3.pickup_category__product--name
                   = product.product_name
@@ -36,11 +30,9 @@
                   sold
         - else
           .pickup_category__containerCategory__product--lists__list
-            = link_to "#" do
+            = link_to product_path(product) do
               %figure.pickup_category__product__images
-                -# 商品一覧実装時はテスト画像利用のためコメントアウト。次回実装時にお使いくださいませ。
-                -# = image_tag product.images.first.image.url
-                = image_tag 'TankTop.png',alt: "image_url", class:"pickup_brand__product__images--image"
+                = image_tag product.images.first.image.url
               .pickup_category__containerCategory__product--lists__list--body
                 %h3.pickup_category__product--name
                   = product.product_name


### PR DESCRIPTION
# what
トップページの「新規投稿商品」の文字リンクより、一覧ページ(index)に遷移するようにした。
一覧ページにて、それぞれの商品画像が出るように変数を指定、各商品の詳細ページへ飛ぶようリンクを作成した。

# why
フリマアプリに必要なページのため。
<img width="1386" alt="スクリーンショット 2020-11-10 16 53 15" src="https://user-images.githubusercontent.com/67197096/98647832-cc907900-2378-11eb-9cb6-9be0689daf10.png">
