### PR TITLE
update

### DIFF
--- a/app/assets/stylesheets/modules/products/_products_edit.scss
+++ b/app/assets/stylesheets/modules/products/_products_edit.scss
@@ -104,10 +104,21 @@
           }
         }
         .category__styleSelect{
-          margin-top: 16px;
           &__selectarea{
             select{
               @include product_select;
+            }
+            &__list{
+              margin-top: 16px;
+              select{
+                @include product_select;
+              }
+            }
+            &__two{
+              margin-top: 16px;
+              select{
+                @include product_select;
+              }
             }
           }
         }

--- a/app/assets/stylesheets/modules/products/_products_new.scss
+++ b/app/assets/stylesheets/modules/products/_products_new.scss
@@ -110,8 +110,8 @@
             }
           }
           &__selectarea__listen__added{
+            margin-top: 16px;
             select{
-              margin-top: 16px;
               @include product_select;
             }
           }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -19,7 +19,7 @@ class ProductsController < ApplicationController
 
   def edit
     @product.images.new
-
+    
     @category_parent_array = ["---"]
     @category_parent_array = Category.where(ancestry: nil)
   end

--- a/app/javascript/products_category.js
+++ b/app/javascript/products_category.js
@@ -4,6 +4,7 @@ $(function(){
     return html;
   }
   function appendChidrenBox(insertHTML){
+    console.log("bbbb")
     var childSelectHtml = '';
     childSelectHtml = `<div class='category__styleSelect__selectarea_listen' id= 'children_wrapper'>
                         <div class='category__styleSelect__selectarea__listen__added'>
@@ -13,7 +14,7 @@ $(function(){
                           <select>
                         </div>
                       </div>`;
-    $('.category__styleSelect__selectarea__listen').append(childSelectHtml);
+    $('.category__styleSelect').append(childSelectHtml);
   }
 
   function appendGrandchidrenBox(insertHTML){
@@ -26,7 +27,7 @@ $(function(){
                                 </select>
                               </div>
                             </div>`;
-    $('.category__styleSelect__selectarea__two').append(grandchildSelectHtml);
+    $('.category__styleSelect').append(grandchildSelectHtml);
   }
 
   $('#parent_category').on('change', function(){

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -59,9 +59,11 @@
                 必須
             .category__styleSelect
               .category__styleSelect__selectarea
-                = f.collection_select :category, Category.where(ancestry: nil), :id, :name, {prompt: '---'}, {id: 'parent_category'}
-              .category__styleSelect__selectarea__listen
-              .category__styleSelect__selectarea__two
+                = f.collection_select :category, Category.where(ancestry: nil), :id, :name, {prompt: '---', selected: @product.category.root_id}, {id: 'parent_category'}
+              .category__styleSelect__selectarea__list#children_wrapper
+                = f.collection_select :category, @product.category.parent.siblings, :id, :name, {prompt: '---', selected: @product.category.parent_id}, {id: 'child_category'}
+              .category__styleSelect__selectarea__two#grandchildren_wrapper
+                = f.collection_select :category_id, @product.category.siblings, :id, :name , {prompt: '---', selected: @product.category_id}, {id: 'grandchild_category'}
         .product__brand__box
           .product__brandField
             .product__brandField__name      


### PR DESCRIPTION
#what
セレクトボックスを元々作成しておく形でのカテゴリーボックスの実装
上のカテゴリーを変更すると、その下のカテゴリーボックスが消える形での実装
商品編集のカテゴリー部分
https://gyazo.com/b376df0fbf6fce2ea5b9fd655594cc8c
https://gyazo.com/90657c0329166769e8372720dff2d902

上のカテゴリーを消した時
https://gyazo.com/c45a0317968f25aa01f1c828763809d0
https://gyazo.com/6635036b5711ed7f61e213607d747ef9

情報編集（一番下のカテゴリーのみを変更した時）
https://gyazo.com/9a0f4a357300962e48df4df116c00446
https://gyazo.com/4786edb280608d7080f37c10e18881dc

why
編集機能の実装に必要だったから